### PR TITLE
remove import of constants from incorrect package

### DIFF
--- a/t/03_callbacks.t
+++ b/t/03_callbacks.t
@@ -43,7 +43,6 @@ plan(tests => scalar(@tests) + 2);
 
 require_ok("Net::OSCAR");
 require_ok("Net::OSCAR::Constants");
-Net::OSCAR::Constant->import(":all");
 
 foreach my $file(@tests) {
 	next if $file eq "." or $file eq "..";

--- a/t/04_server_callbacks.t
+++ b/t/04_server_callbacks.t
@@ -43,7 +43,6 @@ plan(tests => scalar(@tests) + 2);
 
 require_ok("Net::OSCAR");
 require_ok("Net::OSCAR::Constants");
-Net::OSCAR::Constant->import(":all");
 
 foreach my $file(@tests) {
 	next if $file eq "." or $file eq "..";


### PR DESCRIPTION
Two tests were attempting to import from Net::OSCAR::Constant, but the real package is Net::OSCAR::Constants. They were also trying to import the :all tag, which doesn't exist.

Previous versions of perl just ignored these import calls. Future versions are intending to make calls to undefined import methods with arguments an error.